### PR TITLE
fix reset button

### DIFF
--- a/script.js
+++ b/script.js
@@ -59,7 +59,11 @@ addToArrBtnDOM.addEventListener('click', function () {
 //======================
 //Click resetBtn
 resetDOM.addEventListener('click', function () {
-  curArr = defaultArr;
+  // curArr = defaultArr;
+  // You should copy the defaultArr since assigning curArr = defaultArr points to the same object in memory
+  curArr = [...defaultArr];
+
+  
   curArrDOM.textContent = `${curArr}`;
   saveToStorage('CURRENT__ARRAY', JSON.stringify(curArr));
 });


### PR DESCRIPTION
# Fix reset button
there was a small bug in the reset button :
 ## bug:
 * this will points to the same object in the memory (mutating curArr will mutate defaultArr too)
```js
// BUG
 curArr = defaultArr;
```
 ## fix:
 * instead we should copy the object so reset functionality works as intended
 ```js
  curArr = [...defaultArr];
 ```
